### PR TITLE
AI Forge: real AI generation via Claude & OpenAI

### DIFF
--- a/app/ai/page.tsx
+++ b/app/ai/page.tsx
@@ -1,7 +1,9 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import TopBar from "@/components/TopBar";
 import { getAudioContext, getMaster } from "@/lib/audio";
+import { renderPatch, bufferToWav } from "@/lib/forge/render";
+import type { ForgePatch } from "@/lib/forge/patch";
 
 type Gen = {
   id: string;
@@ -11,6 +13,10 @@ type Gen = {
   key: string;
   durationMs: number;
   buffer: AudioBuffer;
+  patch: ForgePatch;
+  source: "ai" | "fallback";
+  provider: string | null;
+  model: string | null;
   createdAt: number;
 };
 
@@ -35,7 +41,11 @@ const PROMPT_IDEAS = [
 ];
 
 const KEYS = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
-const SCALE_MAJOR = [0, 2, 4, 5, 7, 9, 11];
+
+const PROVIDER_LABELS: Record<string, string> = {
+  claude: "Claude",
+  openai: "OpenAI",
+};
 
 export default function AIForgePage() {
   const [authed, setAuthed] = useState<boolean | null>(null);
@@ -46,40 +56,70 @@ export default function AIForgePage() {
   const [duration, setDuration] = useState(1200);
   const [intensity, setIntensity] = useState(0.7);
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [gens, setGens] = useState<Gen[]>([]);
-  const [remaining, setRemaining] = useState<number>(200);
+
+  const [providers, setProviders] = useState<string[]>([]);
+  const [provider, setProvider] = useState<"auto" | "claude" | "openai">("auto");
 
   useEffect(() => {
     fetch("/api/me")
       .then(r => r.json())
       .then(d => setAuthed(!!d?.authenticated))
       .catch(() => setAuthed(false));
+    fetch("/api/forge")
+      .then(r => r.json())
+      .then(d => setProviders(Array.isArray(d?.providers) ? d.providers : []))
+      .catch(() => setProviders([]));
   }, []);
 
   async function generate() {
     if (busy) return;
     setBusy(true);
+    setError(null);
     try {
       const ac = getAudioContext();
       await getMaster();
-      const buffer = await synthesizeSample({
-        ac,
-        preset,
-        durationMs: duration,
-        bpm,
-        keyRoot,
-        intensity,
-        promptHash: hash(prompt),
+
+      const res = await fetch("/api/forge", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          prompt, preset, bpm, keyRoot, durationMs: duration, intensity, provider,
+        }),
       });
+
+      if (res.status === 401) {
+        setAuthed(false);
+        setError("Sign in to forge sounds.");
+        return;
+      }
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        setError(d?.error || "Generation failed.");
+        return;
+      }
+
+      const data = await res.json();
+      const patch: ForgePatch = data.patch;
+      const buffer = await renderPatch(ac, patch);
+
       const id = Math.random().toString(36).slice(2, 9);
       setGens(prev => [
-        { id, prompt, preset, bpm, key: keyRoot, durationMs: duration, buffer, createdAt: Date.now() },
+        {
+          id, prompt, preset, bpm, key: keyRoot, durationMs: patch.durationMs,
+          buffer, patch,
+          source: data.source === "ai" ? "ai" : "fallback",
+          provider: data.provider ?? null,
+          model: data.model ?? null,
+          createdAt: Date.now(),
+        },
         ...prev,
       ]);
-      setRemaining(r => Math.max(0, r - 1));
+    } catch (e: any) {
+      setError(e?.message || "Something went wrong.");
     } finally {
-      // small UI breathing room
-      setTimeout(() => setBusy(false), 300);
+      setBusy(false);
     }
   }
 
@@ -105,7 +145,6 @@ export default function AIForgePage() {
   }
 
   function sendToPads(g: Gen) {
-    // encode WAV to a data URL and drop it into a localStorage queue the studio page can pick up
     const wav = bufferToWav(g.buffer);
     const blob = new Blob([wav], { type: "audio/wav" });
     const reader = new FileReader();
@@ -118,6 +157,8 @@ export default function AIForgePage() {
     reader.readAsDataURL(blob);
   }
 
+  const hasAI = providers.length > 0;
+
   return (
     <main className="min-h-screen">
       <TopBar />
@@ -127,12 +168,15 @@ export default function AIForgePage() {
             <div className="text-xs uppercase tracking-widest text-violet-300 mb-1">AI Sample Forge</div>
             <h1 className="text-3xl md:text-4xl font-bold">Type a vibe. <span className="gradient-text">Get a stem.</span></h1>
             <p className="text-gray-400 mt-2 max-w-2xl">
-              Describe what you want — Soundboard Lab synthesizes a sample on-device. Bounce to WAV, or drop into the pads.
+              An AI reads your description and designs a synthesis patch — oscillators, envelopes, filters, drive.
+              Your browser renders it to audio. Different words, different sound.
             </p>
           </div>
           <div className="glass rounded-xl px-4 py-3 text-sm">
-            <div className="text-[10px] uppercase tracking-widest text-gray-400">Quota this month</div>
-            <div className="font-semibold text-lg">{remaining} <span className="text-gray-500 text-sm font-normal">/ 200</span></div>
+            <div className="text-[10px] uppercase tracking-widest text-gray-400">Engine</div>
+            <div className="font-semibold text-lg">
+              {hasAI ? providers.map(p => PROVIDER_LABELS[p] || p).join(" + ") : "On-device"}
+            </div>
           </div>
         </div>
 
@@ -140,8 +184,15 @@ export default function AIForgePage() {
           <div className="glass rounded-2xl p-6 mb-6 border border-amber-300/20">
             <div className="font-semibold mb-1">Heads up — you're not logged in.</div>
             <p className="text-sm text-gray-400">
-              You can preview the Forge here. <a href="/signup" className="text-violet-300 underline">Sign up free</a> to save and reuse generations.
+              The Forge needs an account to run. <a href="/signup" className="text-violet-300 underline">Sign up free</a> to start generating.
             </p>
+          </div>
+        )}
+
+        {!hasAI && (
+          <div className="glass rounded-2xl p-4 mb-6 border border-white/10 text-sm text-gray-400">
+            No AI provider key is configured on the server, so the Forge is using its built-in prompt-driven synth.
+            Set <code className="text-violet-300">ANTHROPIC_API_KEY</code> or <code className="text-violet-300">OPENAI_API_KEY</code> to enable real AI generation.
           </div>
         )}
 
@@ -230,6 +281,41 @@ export default function AIForgePage() {
               </div>
             </div>
 
+            {hasAI && providers.length > 0 && (
+              <div className="mt-6">
+                <label className="text-xs uppercase tracking-widest text-gray-400">AI model</label>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {providers.length > 1 && (
+                    <button
+                      onClick={() => setProvider("auto")}
+                      className={`text-sm px-3 py-1.5 rounded-lg border ${
+                        provider === "auto" ? "glass-strong gradient-border" : "glass border-white/10 hover:bg-white/[.07]"
+                      }`}
+                    >
+                      Auto
+                    </button>
+                  )}
+                  {providers.map(p => (
+                    <button
+                      key={p}
+                      onClick={() => setProvider(p as "claude" | "openai")}
+                      className={`text-sm px-3 py-1.5 rounded-lg border ${
+                        provider === p ? "glass-strong gradient-border" : "glass border-white/10 hover:bg-white/[.07]"
+                      }`}
+                    >
+                      {PROVIDER_LABELS[p] || p}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {error && (
+              <div className="mt-4 text-sm text-amber-300/90 bg-amber-400/10 border border-amber-300/20 rounded-lg px-3 py-2">
+                {error}
+              </div>
+            )}
+
             <button
               disabled={busy}
               onClick={generate}
@@ -267,9 +353,20 @@ export default function AIForgePage() {
                   <div className="flex items-center justify-between gap-2">
                     <div className="min-w-0">
                       <div className="text-xs text-gray-400 uppercase tracking-widest truncate">
-                        {g.preset} · {g.key} · {g.bpm}bpm · {(g.durationMs / 1000).toFixed(1)}s
+                        {g.preset} · {g.key} · {g.bpm}bpm · {(g.durationMs / 1000).toFixed(1)}s · {g.patch.layers.length} layers
                       </div>
                       <div className="text-sm font-medium truncate">{g.prompt}</div>
+                      <div className="mt-1">
+                        {g.source === "ai" ? (
+                          <span className="text-[10px] px-2 py-0.5 rounded-full bg-violet-500/15 text-violet-200 border border-violet-400/20">
+                            {PROVIDER_LABELS[g.provider || ""] || g.provider} · {g.model}
+                          </span>
+                        ) : (
+                          <span className="text-[10px] px-2 py-0.5 rounded-full bg-white/5 text-gray-400 border border-white/10">
+                            on-device synth
+                          </span>
+                        )}
+                      </div>
                     </div>
                     <div className="flex gap-1 shrink-0">
                       <button onClick={() => playBuffer(g.buffer)} className="btn-ghost rounded-md px-2 py-1 text-sm" title="Play">▶</button>
@@ -284,185 +381,9 @@ export default function AIForgePage() {
         </div>
 
         <p className="text-xs text-gray-500 text-center mt-8">
-          Forge synthesizes audio fully on-device — no audio leaves your browser.
+          Only your text prompt is sent to the AI. The audio itself is synthesized on-device from the AI's patch — no audio leaves your browser.
         </p>
       </div>
     </main>
   );
-}
-
-/* ------------------ procedural synthesis ------------------ */
-
-type SynthOpts = {
-  ac: AudioContext;
-  preset: string;
-  durationMs: number;
-  bpm: number;
-  keyRoot: string;
-  intensity: number;
-  promptHash: number;
-};
-
-function hash(s: string) {
-  let h = 0;
-  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
-  return Math.abs(h);
-}
-
-function noteFreq(root: string, semitoneOffset: number) {
-  const idx = KEYS.indexOf(root);
-  const midi = 60 + idx + semitoneOffset;
-  return 440 * Math.pow(2, (midi - 69) / 12);
-}
-
-async function synthesizeSample(opts: SynthOpts): Promise<AudioBuffer> {
-  const { ac, preset, durationMs, intensity, promptHash, keyRoot } = opts;
-  const sampleRate = ac.sampleRate;
-  const length = Math.floor((durationMs / 1000) * sampleRate);
-  const buf = ac.createBuffer(2, length, sampleRate);
-  const L = buf.getChannelData(0);
-  const R = buf.getChannelData(1);
-
-  const seed = promptHash;
-  const rand = mulberry32(seed);
-
-  const rootFreq = noteFreq(keyRoot, 0);
-
-  for (let i = 0; i < length; i++) {
-    const t = i / sampleRate;
-    const tn = i / length;
-    let v = 0;
-
-    switch (preset) {
-      case "kick": {
-        const pitch = 120 * Math.exp(-tn * 35) + 50;
-        const env = Math.exp(-tn * 6);
-        v = Math.sin(2 * Math.PI * pitch * t) * env;
-        v += (rand() * 2 - 1) * 0.2 * Math.exp(-tn * 60);
-        break;
-      }
-      case "snare": {
-        const noise = rand() * 2 - 1;
-        const env = Math.exp(-tn * 9);
-        const tone = Math.sin(2 * Math.PI * 200 * t) * Math.exp(-tn * 18) * 0.5;
-        v = (noise * 0.8 + tone) * env;
-        break;
-      }
-      case "hat": {
-        const noise = rand() * 2 - 1;
-        const env = Math.exp(-tn * (12 + intensity * 18));
-        v = noise * env * 0.8;
-        // band emphasis around 8k via fake comb
-        v += Math.sin(2 * Math.PI * 7800 * t) * 0.05 * env;
-        break;
-      }
-      case "bass": {
-        const f = rootFreq / 2;
-        const env = Math.exp(-tn * 1.6);
-        v = (Math.sin(2 * Math.PI * f * t) + Math.sin(2 * Math.PI * f * 2 * t) * 0.3) * env;
-        v += Math.sign(Math.sin(2 * Math.PI * f * t)) * 0.15 * env;
-        break;
-      }
-      case "lead": {
-        const f = rootFreq * 2;
-        const detune = 1 + Math.sin(t * 6) * 0.005;
-        const env = Math.exp(-tn * 1.2);
-        v = (saw(f * t) * 0.4 + saw(f * detune * t) * 0.4 + Math.sin(2 * Math.PI * f * t) * 0.2) * env;
-        break;
-      }
-      case "pad": {
-        const env = Math.sin(Math.min(1, tn * 4) * Math.PI / 2) * Math.exp(-tn * 0.6);
-        let sum = 0;
-        for (let n = 0; n < 5; n++) {
-          const semi = SCALE_MAJOR[n % SCALE_MAJOR.length];
-          const f = noteFreq(keyRoot, semi - 12);
-          sum += Math.sin(2 * Math.PI * f * t) * 0.18;
-        }
-        v = sum * env;
-        break;
-      }
-      case "vox": {
-        const f = rootFreq * 1.5;
-        const wob = 1 + Math.sin(t * 4) * 0.02;
-        const env = Math.exp(-tn * 2);
-        v = (Math.sin(2 * Math.PI * f * wob * t) * 0.6 + Math.sin(2 * Math.PI * f * 2 * t) * 0.3) * env;
-        v += (rand() * 2 - 1) * 0.05 * env;
-        break;
-      }
-      case "fx": {
-        const f = 200 + (1 - Math.exp(-tn * 2)) * 4000;
-        const env = Math.sin(tn * Math.PI);
-        v = saw(f * t) * 0.3 * env + (rand() * 2 - 1) * 0.2 * env;
-        break;
-      }
-      default:
-        v = (rand() * 2 - 1) * Math.exp(-tn * 4);
-    }
-
-    const gain = 0.4 + intensity * 0.55;
-    const pan = Math.sin(tn * Math.PI * 2) * 0.15;
-    L[i] = clamp(v * gain * (1 - pan), -1, 1);
-    R[i] = clamp(v * gain * (1 + pan), -1, 1);
-  }
-
-  // tiny fade-out to avoid clicks
-  const fade = Math.min(length, 1024);
-  for (let i = 0; i < fade; i++) {
-    const k = 1 - i / fade;
-    L[length - 1 - i] *= k;
-    R[length - 1 - i] *= k;
-  }
-
-  // pretend we took some thinking time
-  await new Promise(res => setTimeout(res, 650 + (promptHash % 500)));
-  return buf;
-}
-
-function mulberry32(a: number) {
-  return function () {
-    let t = (a += 0x6d2b79f5);
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-function saw(x: number) {
-  const f = x - Math.floor(x);
-  return f * 2 - 1;
-}
-function clamp(v: number, lo: number, hi: number) { return Math.max(lo, Math.min(hi, v)); }
-
-/* ------------------ WAV encoder ------------------ */
-function bufferToWav(buf: AudioBuffer): ArrayBuffer {
-  const numCh = buf.numberOfChannels;
-  const sr = buf.sampleRate;
-  const len = buf.length;
-  const data = new Float32Array(len * numCh);
-  for (let ch = 0; ch < numCh; ch++) {
-    const src = buf.getChannelData(ch);
-    for (let i = 0; i < len; i++) data[i * numCh + ch] = src[i];
-  }
-
-  const bytesPerSample = 2;
-  const blockAlign = numCh * bytesPerSample;
-  const byteRate = sr * blockAlign;
-  const dataSize = data.length * bytesPerSample;
-  const ab = new ArrayBuffer(44 + dataSize);
-  const view = new DataView(ab);
-
-  let p = 0;
-  function ws(s: string) { for (let i = 0; i < s.length; i++) view.setUint8(p++, s.charCodeAt(i)); }
-  function w32(n: number) { view.setUint32(p, n, true); p += 4; }
-  function w16(n: number) { view.setUint16(p, n, true); p += 2; }
-
-  ws("RIFF"); w32(36 + dataSize); ws("WAVE");
-  ws("fmt "); w32(16); w16(1); w16(numCh); w32(sr); w32(byteRate); w16(blockAlign); w16(16);
-  ws("data"); w32(dataSize);
-
-  for (let i = 0; i < data.length; i++) {
-    const s = Math.max(-1, Math.min(1, data[i]));
-    view.setInt16(p, s < 0 ? s * 0x8000 : s * 0x7fff, true);
-    p += 2;
-  }
-  return ab;
 }

--- a/app/api/forge/route.ts
+++ b/app/api/forge/route.ts
@@ -1,0 +1,191 @@
+// app/api/forge/route.ts
+// Turns a text prompt into a synthesis patch using a real LLM. Supports two
+// providers via server-side keys:
+//   - Claude  → ANTHROPIC_API_KEY  (official @anthropic-ai/sdk)
+//   - OpenAI  → OPENAI_API_KEY     (official openai sdk)
+// The model reads the words in the prompt and emits patch JSON, so every
+// prompt produces a genuinely different sound. If no provider is configured
+// (or the call fails), we fall back to a prompt-keyword heuristic so the Forge
+// still varies its output.
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import OpenAI from "openai";
+import { requireUserOrThrow } from "@/lib/auth";
+import {
+  parsePatch,
+  heuristicPatch,
+  type ForgePatch,
+  type ForgeRequest,
+} from "@/lib/forge/patch";
+
+const CLAUDE_MODEL = process.env.FORGE_CLAUDE_MODEL || "claude-opus-4-8";
+const OPENAI_MODEL = process.env.FORGE_OPENAI_MODEL || "gpt-4o";
+
+type Provider = "claude" | "openai";
+
+function configuredProviders(): Provider[] {
+  const list: Provider[] = [];
+  if (process.env.ANTHROPIC_API_KEY) list.push("claude");
+  if (process.env.OPENAI_API_KEY) list.push("openai");
+  return list;
+}
+
+const SYSTEM_PROMPT = `You are a sound-design engine for a browser synthesizer. Given a short text
+description of a sound plus musical parameters, you output ONE JSON object (and
+nothing else) describing how to synthesize it.
+
+Translate the MEANING of the words into synthesis parameters. Two different
+descriptions must produce two different patches — "dark trap kick" and "bright
+glassy pluck" should not look alike. Interpret adjectives:
+- dark/deep/sub -> low filter cutoff, low frequencies, sine/triangle
+- bright/glassy/airy -> high cutoff, saw/square, higher frequencies
+- dirty/gritty/distorted/aggressive -> master.drive up, resonant filter, saw
+- detuned/wide/super/thick -> unison 2-3, detune 8-25 cents, pan spread
+- lo-fi/vinyl/warm -> softer highs, pink noise, gentle drive
+- punchy/snappy -> fast attack, short decay
+- pad/evolving/lush -> long attack & release, sustain > 0
+
+SCHEMA (all numbers must stay in range; omit optional fields to accept defaults):
+{
+  "name": string,
+  "durationMs": 120..6000,
+  "master": { "gain": 0..1, "drive": 0..1 },
+  "layers": [ 1..6 of {
+    "source": "osc" | "noise",
+    "waveform": "sine" | "sawtooth" | "square" | "triangle",   // osc
+    "noiseType": "white" | "pink",                              // noise
+    "freqStart": 20..18000, "freqEnd": 20..18000,               // freqEnd != freqStart = pitch sweep
+    "freqCurve": "linear" | "exp",
+    "detune": -1200..1200 (cents), "unison": 1..3,
+    "gain": 0..1, "pan": -1..1,
+    "amp": { "attack": 0..4, "decay": 0..8, "sustain": 0..1, "release": 0..8 },  // seconds
+    "filter": { "type": "lowpass"|"highpass"|"bandpass", "freqStart": 20..20000, "freqEnd": 20..20000, "q": 0.1..24 }
+  } ]
+}
+
+Drums usually layer a pitched body (osc) with a noise transient. Use the given
+key for tonal sounds (bass/lead/pad/vox). Respect the requested duration and let
+"intensity" push drive, brightness, and length. Output only the JSON object.`;
+
+function userPrompt(req: ForgeRequest): string {
+  return `Description: ${req.prompt}
+Sound type: ${req.preset}
+Key: ${req.keyRoot}
+BPM: ${req.bpm}
+Target duration (ms): ${req.durationMs}
+Intensity (0..1): ${req.intensity}
+
+Return the JSON patch now.`;
+}
+
+/** Pull the first balanced JSON object out of a model's text response. */
+function extractJson(text: string): unknown {
+  const start = text.indexOf("{");
+  if (start === -1) throw new Error("No JSON object in model output");
+  let depth = 0;
+  for (let i = start; i < text.length; i++) {
+    if (text[i] === "{") depth++;
+    else if (text[i] === "}") {
+      depth--;
+      if (depth === 0) return JSON.parse(text.slice(start, i + 1));
+    }
+  }
+  throw new Error("Unbalanced JSON in model output");
+}
+
+async function generateWithClaude(req: ForgeRequest): Promise<ForgePatch> {
+  const client = new Anthropic();
+  const res = await client.messages.create({
+    model: CLAUDE_MODEL,
+    max_tokens: 1500,
+    output_config: { effort: "low" }, // interactive tool — keep latency low
+    system: SYSTEM_PROMPT,
+    messages: [{ role: "user", content: userPrompt(req) }],
+  });
+  const text = res.content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("");
+  return parsePatch(extractJson(text));
+}
+
+async function generateWithOpenAI(req: ForgeRequest): Promise<ForgePatch> {
+  const client = new OpenAI();
+  const res = await client.chat.completions.create({
+    model: OPENAI_MODEL,
+    response_format: { type: "json_object" },
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userPrompt(req) },
+    ],
+  });
+  const text = res.choices[0]?.message?.content || "";
+  return parsePatch(extractJson(text));
+}
+
+/** GET → which providers the server can use, so the UI can offer them. */
+export async function GET() {
+  return NextResponse.json({ providers: configuredProviders() });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    await requireUserOrThrow();
+    const body = await req.json();
+
+    const forgeReq: ForgeRequest = {
+      prompt: String(body?.prompt || "").slice(0, 500),
+      preset: String(body?.preset || "kick"),
+      bpm: Number(body?.bpm) || 120,
+      keyRoot: String(body?.keyRoot || "C"),
+      durationMs: Math.min(6000, Math.max(120, Number(body?.durationMs) || 1200)),
+      intensity: Math.min(1, Math.max(0, Number(body?.intensity) ?? 0.7)),
+    };
+
+    if (!forgeReq.prompt.trim()) {
+      return NextResponse.json({ error: "Prompt is required" }, { status: 400 });
+    }
+
+    const available = configuredProviders();
+    const requested = body?.provider as Provider | "auto" | undefined;
+
+    let provider: Provider | null = null;
+    if (requested && requested !== "auto") {
+      provider = available.includes(requested) ? requested : null;
+    } else {
+      provider = available[0] ?? null;
+    }
+
+    if (provider) {
+      try {
+        const patch =
+          provider === "claude"
+            ? await generateWithClaude(forgeReq)
+            : await generateWithOpenAI(forgeReq);
+        return NextResponse.json({
+          patch,
+          provider,
+          model: provider === "claude" ? CLAUDE_MODEL : OPENAI_MODEL,
+          source: "ai",
+        });
+      } catch (e: any) {
+        // Fall through to the heuristic so the user still gets a sound.
+        console.error("[forge] AI generation failed:", e?.message || e);
+      }
+    }
+
+    return NextResponse.json({
+      patch: heuristicPatch(forgeReq),
+      provider: null,
+      model: null,
+      source: "fallback",
+      reason: available.length === 0 ? "no-provider-configured" : "ai-error",
+    });
+  } catch (e: any) {
+    const status = e?.message === "UNAUTHENTICATED" ? 401 : 500;
+    return NextResponse.json(
+      { error: status === 401 ? "Sign in to use the Forge" : "Failed to generate" },
+      { status }
+    );
+  }
+}

--- a/lib/forge/patch.ts
+++ b/lib/forge/patch.ts
@@ -1,0 +1,221 @@
+// lib/forge/patch.ts
+// The "patch" is the shared contract between the LLM, the API route, and the
+// audio renderer. An LLM reads the user's prompt and emits one of these; the
+// renderer (lib/forge/render.ts) turns it into an AudioBuffer. Because the
+// numbers come from the words in the prompt, every prompt yields a different
+// sound — that's the whole point of the Forge.
+import { z } from "zod";
+
+const clamp01 = z.number().min(0).max(1);
+
+/** ADSR envelope, seconds (except sustain which is a 0..1 level). */
+export const EnvSchema = z.object({
+  attack: z.number().min(0).max(4).default(0.005),
+  decay: z.number().min(0).max(8).default(0.2),
+  sustain: clamp01.default(0),
+  release: z.number().min(0).max(8).default(0.1),
+});
+
+export const FilterSchema = z.object({
+  type: z.enum(["lowpass", "highpass", "bandpass"]).default("lowpass"),
+  freqStart: z.number().min(20).max(20000).default(20000),
+  freqEnd: z.number().min(20).max(20000).default(20000),
+  q: z.number().min(0.1).max(24).default(0.7),
+});
+
+export const LayerSchema = z.object({
+  // "osc" = pitched oscillator, "noise" = noise source (drums/air/fx).
+  source: z.enum(["osc", "noise"]).default("osc"),
+  waveform: z.enum(["sine", "sawtooth", "square", "triangle"]).default("sine"),
+  noiseType: z.enum(["white", "pink"]).default("white"),
+
+  // Pitch. freqStart != freqEnd gives a pitch sweep (kicks, risers, zaps).
+  freqStart: z.number().min(20).max(18000).default(220),
+  freqEnd: z.number().min(20).max(18000).default(220),
+  freqCurve: z.enum(["linear", "exp"]).default("exp"),
+
+  detune: z.number().min(-1200).max(1200).default(0), // cents
+  unison: z.number().int().min(1).max(3).default(1),   // stacked detuned voices
+
+  gain: clamp01.default(0.7),
+  pan: z.number().min(-1).max(1).default(0),
+
+  amp: EnvSchema.default({ attack: 0.005, decay: 0.2, sustain: 0, release: 0.1 }),
+  filter: FilterSchema.optional(),
+});
+
+export const PatchSchema = z.object({
+  name: z.string().max(80).default("Forged sound"),
+  durationMs: z.number().min(120).max(6000).default(1200),
+  layers: z.array(LayerSchema).min(1).max(6),
+  master: z
+    .object({
+      gain: clamp01.default(0.85),
+      drive: clamp01.default(0), // waveshaper saturation amount
+    })
+    .default({ gain: 0.85, drive: 0 }),
+});
+
+export type Env = z.infer<typeof EnvSchema>;
+export type Filter = z.infer<typeof FilterSchema>;
+export type Layer = z.infer<typeof LayerSchema>;
+export type ForgePatch = z.infer<typeof PatchSchema>;
+
+export type ForgeRequest = {
+  prompt: string;
+  preset: string;
+  bpm: number;
+  keyRoot: string;
+  durationMs: number;
+  intensity: number;
+};
+
+export const KEYS = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+
+/** MIDI-note frequency for a root name + semitone offset. Octave ~4. */
+export function noteFreq(root: string, semitoneOffset = 0) {
+  const idx = Math.max(0, KEYS.indexOf(root));
+  const midi = 60 + idx + semitoneOffset;
+  return 440 * Math.pow(2, (midi - 69) / 12);
+}
+
+/**
+ * Parse arbitrary JSON from an LLM into a validated patch, clamping every
+ * value into range. Throws if the shape is unusable.
+ */
+export function parsePatch(raw: unknown): ForgePatch {
+  return PatchSchema.parse(raw);
+}
+
+/**
+ * A prompt-aware fallback used when no AI provider is configured or the model
+ * call fails. It's deliberately keyword-driven so that — unlike the old fixed
+ * synth — the words in the prompt still change the result.
+ */
+export function heuristicPatch(req: ForgeRequest): ForgePatch {
+  const p = req.prompt.toLowerCase();
+  const has = (...words: string[]) => words.some((w) => p.includes(w));
+  const root = noteFreq(req.keyRoot, 0);
+  const intensity = req.intensity;
+
+  // Descriptor knobs mined from the prompt text.
+  const dark = has("dark", "deep", "murky", "sub", "moody", "low");
+  const bright = has("bright", "glassy", "shiny", "crisp", "airy", "sharp", "hyper");
+  const dirty = has("dirty", "gritty", "distort", "saturat", "crunch", "aggress", "hard");
+  const detuned = has("detune", "wide", "super", "unison", "chorus", "thick");
+  const vinyl = has("vinyl", "lo-fi", "lofi", "dusty", "tape", "old", "warm");
+  const drive = Math.min(1, (dirty ? 0.6 : 0.12) + intensity * 0.35);
+
+  let cutoff = 20000;
+  if (dark) cutoff = 900 + intensity * 1200;
+  else if (bright) cutoff = 20000;
+  else cutoff = 3000 + intensity * 6000;
+
+  const layers: Layer[] = [];
+
+  switch (req.preset) {
+    case "kick":
+      layers.push({
+        source: "osc", waveform: "sine", noiseType: "white",
+        freqStart: dark ? 160 : 130, freqEnd: 45, freqCurve: "exp",
+        detune: 0, unison: 1, gain: 0.95, pan: 0,
+        amp: { attack: 0.001, decay: 0.28 + intensity * 0.25, sustain: 0, release: 0.05 },
+      });
+      layers.push({
+        source: "noise", waveform: "sine", noiseType: "white",
+        freqStart: 200, freqEnd: 200, freqCurve: "linear",
+        detune: 0, unison: 1, gain: 0.25 + intensity * 0.2, pan: 0,
+        amp: { attack: 0.0005, decay: 0.02, sustain: 0, release: 0.01 },
+        filter: { type: "lowpass", freqStart: 6000, freqEnd: 2000, q: 0.7 },
+      });
+      break;
+    case "snare":
+      layers.push({
+        source: "noise", waveform: "sine", noiseType: vinyl ? "pink" : "white",
+        freqStart: 400, freqEnd: 400, freqCurve: "linear",
+        detune: 0, unison: 1, gain: 0.85, pan: 0,
+        amp: { attack: 0.001, decay: 0.14 + intensity * 0.12, sustain: 0, release: 0.05 },
+        filter: { type: "highpass", freqStart: dark ? 700 : 1400, freqEnd: 1200, q: 0.8 },
+      });
+      layers.push({
+        source: "osc", waveform: "triangle", noiseType: "white",
+        freqStart: 190, freqEnd: 150, freqCurve: "exp",
+        detune: 0, unison: 1, gain: 0.4, pan: 0,
+        amp: { attack: 0.001, decay: 0.08, sustain: 0, release: 0.03 },
+      });
+      break;
+    case "hat":
+      layers.push({
+        source: "noise", waveform: "sine", noiseType: "white",
+        freqStart: 8000, freqEnd: 8000, freqCurve: "linear",
+        detune: 0, unison: 1, gain: 0.7, pan: 0,
+        amp: { attack: 0.0005, decay: 0.03 + intensity * 0.08, sustain: 0, release: 0.02 },
+        filter: { type: "highpass", freqStart: 7000, freqEnd: 9000, q: 1.2 },
+      });
+      break;
+    case "bass":
+      layers.push({
+        source: "osc", waveform: dirty ? "sawtooth" : "square",
+        noiseType: "white",
+        freqStart: root / 2, freqEnd: root / 2, freqCurve: "linear",
+        detune: detuned ? 8 : 0, unison: detuned ? 2 : 1, gain: 0.9, pan: 0,
+        amp: { attack: 0.005, decay: 0.3, sustain: 0.8, release: 0.2 },
+        filter: { type: "lowpass", freqStart: cutoff, freqEnd: cutoff * 0.6, q: dirty ? 6 : 1 },
+      });
+      break;
+    case "lead":
+      layers.push({
+        source: "osc", waveform: "sawtooth", noiseType: "white",
+        freqStart: root * 2, freqEnd: root * 2, freqCurve: "linear",
+        detune: detuned ? 14 : 4, unison: detuned ? 3 : 2, gain: 0.7, pan: 0,
+        amp: { attack: 0.01, decay: 0.4, sustain: 0.7, release: 0.3 },
+        filter: { type: "lowpass", freqStart: cutoff, freqEnd: cutoff, q: 2 },
+      });
+      break;
+    case "pad":
+      for (let i = 0; i < 3; i++) {
+        const semis = [0, 7, 12][i];
+        layers.push({
+          source: "osc", waveform: "sawtooth", noiseType: "white",
+          freqStart: noteFreq(req.keyRoot, semis - 12),
+          freqEnd: noteFreq(req.keyRoot, semis - 12), freqCurve: "linear",
+          detune: detuned ? 10 : 3, unison: 2, gain: 0.35, pan: i === 1 ? -0.3 : i === 2 ? 0.3 : 0,
+          amp: { attack: 0.6 + intensity * 0.4, decay: 1.0, sustain: 0.6, release: 1.2 },
+          filter: { type: "lowpass", freqStart: cutoff * 0.6, freqEnd: cutoff, q: 0.8 },
+        });
+      }
+      break;
+    case "vox":
+      layers.push({
+        source: "osc", waveform: "sawtooth", noiseType: "white",
+        freqStart: root * 1.5, freqEnd: root * 1.5, freqCurve: "linear",
+        detune: 6, unison: 2, gain: 0.6, pan: 0,
+        amp: { attack: 0.02, decay: 0.5, sustain: 0.5, release: 0.3 },
+        filter: { type: "bandpass", freqStart: 1200, freqEnd: 800, q: 4 },
+      });
+      break;
+    case "fx":
+    default:
+      layers.push({
+        source: "noise", waveform: "sine", noiseType: "white",
+        freqStart: 200, freqEnd: 200, freqCurve: "linear",
+        detune: 0, unison: 1, gain: 0.6, pan: 0,
+        amp: { attack: req.durationMs / 2000, decay: 0.1, sustain: 0.4, release: req.durationMs / 2000 },
+        filter: { type: "bandpass", freqStart: 200, freqEnd: 8000, q: 3 },
+      });
+      layers.push({
+        source: "osc", waveform: "sawtooth", noiseType: "white",
+        freqStart: 200, freqEnd: 4000, freqCurve: "exp",
+        detune: 12, unison: 2, gain: 0.3, pan: 0,
+        amp: { attack: req.durationMs / 2000, decay: 0.1, sustain: 0.5, release: 0.3 },
+      });
+      break;
+  }
+
+  return PatchSchema.parse({
+    name: `${req.preset} · ${req.prompt.slice(0, 40)}`,
+    durationMs: req.durationMs,
+    layers,
+    master: { gain: 0.85, drive },
+  });
+}

--- a/lib/forge/render.ts
+++ b/lib/forge/render.ts
@@ -1,0 +1,183 @@
+// lib/forge/render.ts
+// Renders a ForgePatch into an AudioBuffer using OfflineAudioContext. Real
+// Web-Audio nodes (oscillators, biquad filters, gain envelopes, waveshaper
+// drive) give far richer results than hand-rolled sample math, and let an
+// arbitrary AI-authored patch map straight onto audio. Browser-only.
+import type { ForgePatch, Layer } from "./patch";
+
+function makeNoiseBuffer(ctx: BaseAudioContext, seconds: number, type: "white" | "pink") {
+  const len = Math.max(1, Math.floor(seconds * ctx.sampleRate));
+  const buf = ctx.createBuffer(1, len, ctx.sampleRate);
+  const data = buf.getChannelData(0);
+  if (type === "pink") {
+    // Paul Kellet's economical pink-noise approximation.
+    let b0 = 0, b1 = 0, b2 = 0, b3 = 0, b4 = 0, b5 = 0, b6 = 0;
+    for (let i = 0; i < len; i++) {
+      const w = Math.random() * 2 - 1;
+      b0 = 0.99886 * b0 + w * 0.0555179;
+      b1 = 0.99332 * b1 + w * 0.0750759;
+      b2 = 0.969 * b2 + w * 0.153852;
+      b3 = 0.8665 * b3 + w * 0.3104856;
+      b4 = 0.55 * b4 + w * 0.5329522;
+      b5 = -0.7616 * b5 - w * 0.016898;
+      data[i] = (b0 + b1 + b2 + b3 + b4 + b5 + b6 + w * 0.5362) * 0.11;
+      b6 = w * 0.115926;
+    }
+  } else {
+    for (let i = 0; i < len; i++) data[i] = Math.random() * 2 - 1;
+  }
+  return buf;
+}
+
+/** Soft-clip curve for the master waveshaper; amount 0..1. */
+function driveCurve(amount: number) {
+  const k = amount * 100;
+  const n = 1024;
+  const curve = new Float32Array(n);
+  for (let i = 0; i < n; i++) {
+    const x = (i * 2) / n - 1;
+    curve[i] = ((1 + k) * x) / (1 + k * Math.abs(x));
+  }
+  return curve;
+}
+
+function applyAmpEnv(param: AudioParam, env: Layer["amp"], gain: number, t0: number, dur: number) {
+  const peak = Math.max(0.0001, gain);
+  const sustainLvl = Math.max(0.0001, peak * env.sustain);
+  const attackEnd = t0 + env.attack;
+  const decayEnd = attackEnd + env.decay;
+
+  param.setValueAtTime(0.0001, t0);
+  param.linearRampToValueAtTime(peak, attackEnd);
+  param.exponentialRampToValueAtTime(sustainLvl, decayEnd);
+
+  // Release begins so it lands right at the end of the buffer.
+  const releaseStart = Math.max(decayEnd, t0 + dur - env.release);
+  param.setValueAtTime(Math.max(0.0001, param.value || sustainLvl), releaseStart);
+  param.exponentialRampToValueAtTime(0.0001, t0 + dur);
+}
+
+function renderLayer(ctx: OfflineAudioContext, layer: Layer, out: AudioNode, dur: number) {
+  const t0 = 0;
+
+  // Envelope + panning chain shared by all voices in this layer.
+  const ampGain = ctx.createGain();
+  ampGain.gain.value = 0.0001;
+  applyAmpEnv(ampGain.gain, layer.amp, layer.gain, t0, dur);
+
+  let tail: AudioNode = ampGain;
+  if (layer.filter) {
+    const biquad = ctx.createBiquadFilter();
+    biquad.type = layer.filter.type;
+    biquad.Q.value = layer.filter.q;
+    biquad.frequency.setValueAtTime(layer.filter.freqStart, t0);
+    biquad.frequency.linearRampToValueAtTime(layer.filter.freqEnd, t0 + dur);
+    ampGain.connect(biquad);
+    tail = biquad;
+  }
+
+  const panner = ctx.createStereoPanner();
+  panner.pan.value = Math.max(-1, Math.min(1, layer.pan));
+  tail.connect(panner);
+  panner.connect(out);
+
+  if (layer.source === "noise") {
+    const src = ctx.createBufferSource();
+    src.buffer = makeNoiseBuffer(ctx, dur, layer.noiseType);
+    src.connect(ampGain);
+    src.start(t0);
+    src.stop(t0 + dur);
+    return;
+  }
+
+  // Oscillator layer, optionally with detuned unison voices.
+  const voices = Math.max(1, layer.unison);
+  for (let v = 0; v < voices; v++) {
+    const osc = ctx.createOscillator();
+    osc.type = layer.waveform;
+    // Spread unison voices symmetrically around the base detune.
+    const spread = voices > 1 ? (v - (voices - 1) / 2) * layer.detune : 0;
+    osc.detune.value = layer.detune + spread;
+    osc.frequency.setValueAtTime(Math.max(20, layer.freqStart), t0);
+    if (layer.freqEnd !== layer.freqStart) {
+      const target = Math.max(20, layer.freqEnd);
+      if (layer.freqCurve === "exp") osc.frequency.exponentialRampToValueAtTime(target, t0 + dur);
+      else osc.frequency.linearRampToValueAtTime(target, t0 + dur);
+    }
+    const vGain = ctx.createGain();
+    vGain.gain.value = 1 / voices;
+    osc.connect(vGain).connect(ampGain);
+    osc.start(t0);
+    osc.stop(t0 + dur);
+  }
+}
+
+/** Render a patch to a stereo AudioBuffer. `ctx` supplies the sample rate. */
+export async function renderPatch(ctx: AudioContext, patch: ForgePatch): Promise<AudioBuffer> {
+  const dur = patch.durationMs / 1000;
+  const length = Math.max(1, Math.ceil(dur * ctx.sampleRate));
+  const offline = new OfflineAudioContext(2, length, ctx.sampleRate);
+
+  const master = offline.createGain();
+  master.gain.value = patch.master.gain;
+
+  let masterTail: AudioNode = master;
+  if (patch.master.drive > 0.01) {
+    const shaper = offline.createWaveShaper();
+    shaper.curve = driveCurve(patch.master.drive);
+    shaper.oversample = "2x";
+    master.connect(shaper);
+    masterTail = shaper;
+  }
+  masterTail.connect(offline.destination);
+
+  for (const layer of patch.layers) renderLayer(offline, layer, master, dur);
+
+  const rendered = await offline.startRendering();
+
+  // Tiny fade to kill any edge clicks.
+  const fade = Math.min(rendered.length, 512);
+  for (let ch = 0; ch < rendered.numberOfChannels; ch++) {
+    const d = rendered.getChannelData(ch);
+    for (let i = 0; i < fade; i++) {
+      d[i] *= i / fade;
+      d[rendered.length - 1 - i] *= i / fade;
+    }
+  }
+  return rendered;
+}
+
+/** Encode an AudioBuffer to a 16-bit PCM WAV ArrayBuffer. */
+export function bufferToWav(buf: AudioBuffer): ArrayBuffer {
+  const numCh = buf.numberOfChannels;
+  const sr = buf.sampleRate;
+  const len = buf.length;
+  const data = new Float32Array(len * numCh);
+  for (let ch = 0; ch < numCh; ch++) {
+    const src = buf.getChannelData(ch);
+    for (let i = 0; i < len; i++) data[i * numCh + ch] = src[i];
+  }
+
+  const bytesPerSample = 2;
+  const blockAlign = numCh * bytesPerSample;
+  const byteRate = sr * blockAlign;
+  const dataSize = data.length * bytesPerSample;
+  const ab = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(ab);
+
+  let p = 0;
+  const ws = (s: string) => { for (let i = 0; i < s.length; i++) view.setUint8(p++, s.charCodeAt(i)); };
+  const w32 = (n: number) => { view.setUint32(p, n, true); p += 4; };
+  const w16 = (n: number) => { view.setUint16(p, n, true); p += 2; };
+
+  ws("RIFF"); w32(36 + dataSize); ws("WAVE");
+  ws("fmt "); w32(16); w16(1); w16(numCh); w32(sr); w32(byteRate); w16(blockAlign); w16(16);
+  ws("data"); w32(dataSize);
+
+  for (let i = 0; i < data.length; i++) {
+    const s = Math.max(-1, Math.min(1, data[i]));
+    view.setInt16(p, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+    p += 2;
+  }
+  return ab;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "soundboard-lab",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.109.0",
         "@prisma/client": "^6.14.0",
         "bcrypt": "^6.0.0",
         "cookie": "^1.0.2",
         "formidable": "^3.5.4",
         "jsonwebtoken": "^9.0.2",
         "next": "15.4.6",
+        "openai": "^6.45.0",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "resend": "^6.0.1",
@@ -51,6 +53,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.109.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.109.0.tgz",
+      "integrity": "sha512-y7P4eLyW5uNut4fXpOUEHqhJwx7dnxrWAfCQE4Lcgm0hSFQuIeHa7CWEKE5dFolEjQJE/RFKkppjri05r2OK/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1126,6 +1158,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -3640,6 +3678,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4688,6 +4732,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -5352,6 +5409,36 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {
@@ -6304,6 +6391,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -6834,6 +6931,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
     "seed": "node prisma/seed.cjs"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.109.0",
     "@prisma/client": "^6.14.0",
     "bcrypt": "^6.0.0",
     "cookie": "^1.0.2",
     "formidable": "^3.5.4",
     "jsonwebtoken": "^9.0.2",
     "next": "15.4.6",
+    "openai": "^6.45.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "resend": "^6.0.1",


### PR DESCRIPTION
The AI Forge never actually used AI. It ran a fixed procedural synth where each preset was a hard-coded formula and the prompt only seeded a noise RNG, so the same preset produced identical audio regardless of the words typed.

Replace it with a real pipeline: an LLM reads the prompt and emits a synthesis "patch" (oscillators, envelopes, filters, noise, drive as JSON); the browser renders that patch to audio via OfflineAudioContext. Different words now yield genuinely different sounds.

- lib/forge/patch.ts: zod-validated patch schema (shared LLM/API/renderer contract) plus a prompt-keyword-driven fallback generator.
- lib/forge/render.ts: OfflineAudioContext renderer (oscillators, biquad filters, ADSR, unison detune, waveshaper drive) + WAV encoder.
- app/api/forge/route.ts: POST generates a patch via Claude (official @anthropic-ai/sdk) or OpenAI (official openai sdk); GET reports configured providers. Server-side keys only; auth required to protect API spend.
- app/ai/page.tsx: calls the API, renders the patch, provider selector, per-generation model badge, graceful on-device fallback.

Enable by setting ANTHROPIC_API_KEY and/or OPENAI_API_KEY (optional FORGE_CLAUDE_MODEL / FORGE_OPENAI_MODEL overrides). With no key, the prompt-driven on-device synth still varies output by prompt wording.