### PR TITLE
Add per-user API key management for AI Forge

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,0 +1,219 @@
+"use client";
+import { useEffect, useState } from "react";
+import TopBar from "@/components/TopBar";
+
+type KeyStatus = { configured: boolean; last4: string | null };
+type KeysResponse = { anthropic: KeyStatus; openai: KeyStatus };
+
+type Provider = "anthropic" | "openai";
+
+const PROVIDER_META: Record<Provider, { label: string; placeholder: string; help: string }> = {
+  anthropic: {
+    label: "Claude (Anthropic)",
+    placeholder: "sk-ant-...",
+    help: "Used by the AI Forge to generate synthesis patches with Claude.",
+  },
+  openai: {
+    label: "OpenAI",
+    placeholder: "sk-...",
+    help: "Used by the AI Forge to generate synthesis patches with GPT models.",
+  },
+};
+
+export default function AccountPage() {
+  const [authed, setAuthed] = useState<boolean | null>(null);
+  const [email, setEmail] = useState<string | null>(null);
+  const [plan, setPlan] = useState<string | null>(null);
+  const [keys, setKeys] = useState<KeysResponse | null>(null);
+
+  const [drafts, setDrafts] = useState<Record<Provider, string>>({ anthropic: "", openai: "" });
+  const [busy, setBusy] = useState<Provider | null>(null);
+  const [status, setStatus] = useState<Record<Provider, { ok?: string; err?: string }>>({
+    anthropic: {},
+    openai: {},
+  });
+
+  useEffect(() => {
+    fetch("/api/me")
+      .then(r => r.json())
+      .then(d => {
+        setAuthed(!!d?.authenticated);
+        setEmail(d?.email ?? null);
+        setPlan(d?.plan ?? null);
+      })
+      .catch(() => setAuthed(false));
+
+    fetch("/api/account/keys")
+      .then(r => (r.ok ? r.json() : null))
+      .then(d => d && setKeys(d))
+      .catch(() => {});
+  }, []);
+
+  async function saveKey(provider: Provider) {
+    const apiKey = drafts[provider].trim();
+    if (!apiKey) return;
+    setBusy(provider);
+    setStatus(s => ({ ...s, [provider]: {} }));
+    try {
+      const res = await fetch("/api/account/keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider, apiKey }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setStatus(s => ({ ...s, [provider]: { err: data?.error || "Failed to save" } }));
+        return;
+      }
+      setKeys(prev => ({
+        anthropic: prev?.anthropic ?? { configured: false, last4: null },
+        openai: prev?.openai ?? { configured: false, last4: null },
+        [provider]: { configured: true, last4: data.last4 },
+      }));
+      setDrafts(d => ({ ...d, [provider]: "" }));
+      setStatus(s => ({ ...s, [provider]: { ok: "Saved" } }));
+    } catch {
+      setStatus(s => ({ ...s, [provider]: { err: "Network error" } }));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function removeKey(provider: Provider) {
+    setBusy(provider);
+    setStatus(s => ({ ...s, [provider]: {} }));
+    try {
+      const res = await fetch("/api/account/keys", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setStatus(s => ({ ...s, [provider]: { err: data?.error || "Failed to remove" } }));
+        return;
+      }
+      setKeys(prev => ({
+        anthropic: prev?.anthropic ?? { configured: false, last4: null },
+        openai: prev?.openai ?? { configured: false, last4: null },
+        [provider]: { configured: false, last4: null },
+      }));
+      setStatus(s => ({ ...s, [provider]: { ok: "Removed" } }));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (authed === false) {
+    return (
+      <main className="min-h-screen">
+        <TopBar />
+        <div className="mx-auto max-w-2xl px-4 py-16 text-center">
+          <div className="glass rounded-2xl p-8">
+            <div className="font-semibold mb-1">You&rsquo;re not logged in.</div>
+            <p className="text-sm text-gray-400 mb-4">Sign in to manage your account and API keys.</p>
+            <a href="/login" className="btn-primary rounded-lg px-4 py-2 text-sm inline-block">Log in</a>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen">
+      <TopBar />
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <div className="mb-6">
+          <div className="text-xs uppercase tracking-widest text-violet-300 mb-1">Account</div>
+          <h1 className="text-3xl font-bold">Settings</h1>
+        </div>
+
+        {/* Profile */}
+        <section className="glass-strong rounded-2xl p-6 mb-6">
+          <div className="font-semibold mb-4">Profile</div>
+          <div className="grid grid-cols-2 gap-4 text-sm max-w-md">
+            <div>
+              <div className="text-xs uppercase tracking-widest text-gray-400 mb-1">Email</div>
+              <div className="text-gray-100">{email || "—"}</div>
+            </div>
+            <div>
+              <div className="text-xs uppercase tracking-widest text-gray-400 mb-1">Plan</div>
+              <div className="text-gray-100">
+                {plan === "PRO" ? <span className="pro-badge px-2 py-0.5 rounded-md text-xs">★ PRO</span> : plan || "FREE"}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* API keys */}
+        <section className="glass-strong rounded-2xl p-6">
+          <div className="font-semibold mb-1">AI Forge — API keys</div>
+          <p className="text-sm text-gray-400 mb-5">
+            Bring your own key so AI Forge generations run on your account. Keys are encrypted and never
+            shown again in full. If you don&rsquo;t add one, the Forge falls back to the server&rsquo;s shared key (if
+            configured) or an on-device fallback synth.
+          </p>
+
+          <div className="space-y-5">
+            {(["anthropic", "openai"] as Provider[]).map(provider => {
+              const meta = PROVIDER_META[provider];
+              const k = keys?.[provider];
+              const s = status[provider];
+              return (
+                <div key={provider} className="rounded-xl glass p-4">
+                  <div className="flex items-center justify-between gap-3 flex-wrap">
+                    <div>
+                      <div className="font-medium text-sm">{meta.label}</div>
+                      <div className="text-xs text-gray-400 mt-0.5">{meta.help}</div>
+                    </div>
+                    {k?.configured && (
+                      <span className="text-[10px] px-2 py-1 rounded-full bg-emerald-500/15 text-emerald-300 border border-emerald-400/20 shrink-0">
+                        Connected · ····{k.last4}
+                      </span>
+                    )}
+                  </div>
+
+                  <div className="mt-3 flex gap-2 flex-wrap">
+                    <input
+                      type="password"
+                      autoComplete="off"
+                      spellCheck={false}
+                      className="flex-1 min-w-[220px] bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-sm outline-none focus:border-violet-400/60"
+                      placeholder={k?.configured ? "Replace key…" : meta.placeholder}
+                      value={drafts[provider]}
+                      onChange={e => setDrafts(d => ({ ...d, [provider]: e.target.value }))}
+                    />
+                    <button
+                      onClick={() => saveKey(provider)}
+                      disabled={busy === provider || !drafts[provider].trim()}
+                      className="btn-primary rounded-lg px-4 py-2 text-sm disabled:opacity-50"
+                    >
+                      {busy === provider ? "Saving…" : "Save"}
+                    </button>
+                    {k?.configured && (
+                      <button
+                        onClick={() => removeKey(provider)}
+                        disabled={busy === provider}
+                        className="btn-ghost rounded-lg px-3 py-2 text-sm text-rose-300 disabled:opacity-50"
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </div>
+
+                  {s?.ok && <div className="mt-2 text-xs text-emerald-300">{s.ok}</div>}
+                  {s?.err && <div className="mt-2 text-xs text-amber-300">{s.err}</div>}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        <p className="text-xs text-gray-500 text-center mt-8">
+          Keys are encrypted at rest and used only to call the respective provider on your behalf when you
+          use the AI Forge.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/app/ai/page.tsx
+++ b/app/ai/page.tsx
@@ -17,6 +17,7 @@ type Gen = {
   source: "ai" | "fallback";
   provider: string | null;
   model: string | null;
+  keySource: "user" | "server" | null;
   createdAt: number;
 };
 
@@ -112,6 +113,7 @@ export default function AIForgePage() {
           source: data.source === "ai" ? "ai" : "fallback",
           provider: data.provider ?? null,
           model: data.model ?? null,
+          keySource: data.keySource ?? null,
           createdAt: Date.now(),
         },
         ...prev,
@@ -182,17 +184,17 @@ export default function AIForgePage() {
 
         {authed === false && (
           <div className="glass rounded-2xl p-6 mb-6 border border-amber-300/20">
-            <div className="font-semibold mb-1">Heads up — you're not logged in.</div>
+            <div className="font-semibold mb-1">Heads up — you&rsquo;re not logged in.</div>
             <p className="text-sm text-gray-400">
               The Forge needs an account to run. <a href="/signup" className="text-violet-300 underline">Sign up free</a> to start generating.
             </p>
           </div>
         )}
 
-        {!hasAI && (
+        {authed && !hasAI && (
           <div className="glass rounded-2xl p-4 mb-6 border border-white/10 text-sm text-gray-400">
-            No AI provider key is configured on the server, so the Forge is using its built-in prompt-driven synth.
-            Set <code className="text-violet-300">ANTHROPIC_API_KEY</code> or <code className="text-violet-300">OPENAI_API_KEY</code> to enable real AI generation.
+            No Claude or OpenAI key is available, so the Forge is using its built-in prompt-driven synth.{" "}
+            <a href="/account" className="text-violet-300 underline">Add your own API key in Settings</a> to enable real AI generation.
           </div>
         )}
 
@@ -360,6 +362,7 @@ export default function AIForgePage() {
                         {g.source === "ai" ? (
                           <span className="text-[10px] px-2 py-0.5 rounded-full bg-violet-500/15 text-violet-200 border border-violet-400/20">
                             {PROVIDER_LABELS[g.provider || ""] || g.provider} · {g.model}
+                            {g.keySource === "user" ? " · your key" : g.keySource === "server" ? " · shared key" : ""}
                           </span>
                         ) : (
                           <span className="text-[10px] px-2 py-0.5 rounded-full bg-white/5 text-gray-400 border border-white/10">
@@ -381,7 +384,7 @@ export default function AIForgePage() {
         </div>
 
         <p className="text-xs text-gray-500 text-center mt-8">
-          Only your text prompt is sent to the AI. The audio itself is synthesized on-device from the AI's patch — no audio leaves your browser.
+          Only your text prompt is sent to the AI. The audio itself is synthesized on-device from the AI&rsquo;s patch — no audio leaves your browser.
         </p>
       </div>
     </main>

--- a/app/api/account/keys/route.ts
+++ b/app/api/account/keys/route.ts
@@ -1,0 +1,95 @@
+// app/api/account/keys/route.ts
+// Lets a signed-in user store their own Claude / OpenAI API key so AI Forge
+// generations run against their account instead of (or before) the server's
+// shared key. Keys are encrypted at rest (lib/crypto.ts) and never returned
+// to the client in full — only a last-4 fingerprint for display.
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { requireUserOrThrow } from "@/lib/auth";
+import { encryptSecret, last4 } from "@/lib/crypto";
+
+type Provider = "anthropic" | "openai";
+
+const PREFIXES: Record<Provider, string> = {
+  anthropic: "sk-ant-",
+  openai: "sk-",
+};
+
+function fieldNames(provider: Provider) {
+  return provider === "anthropic"
+    ? { enc: "anthropicKeyEnc", last4: "anthropicKeyLast4" } as const
+    : { enc: "openaiKeyEnc", last4: "openaiKeyLast4" } as const;
+}
+
+export async function GET() {
+  try {
+    const user = await requireUserOrThrow();
+    return NextResponse.json({
+      anthropic: { configured: !!user.anthropicKeyEnc, last4: user.anthropicKeyLast4 },
+      openai: { configured: !!user.openaiKeyEnc, last4: user.openaiKeyLast4 },
+    });
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const user = await requireUserOrThrow();
+    const body = await req.json().catch(() => ({}));
+    const provider = body?.provider as Provider;
+    const apiKey = String(body?.apiKey || "").trim();
+
+    if (provider !== "anthropic" && provider !== "openai") {
+      return NextResponse.json({ error: "Unknown provider" }, { status: 400 });
+    }
+    if (apiKey.length < 20 || apiKey.length > 400) {
+      return NextResponse.json({ error: "That doesn't look like a valid API key" }, { status: 400 });
+    }
+    if (!apiKey.startsWith(PREFIXES[provider])) {
+      return NextResponse.json(
+        { error: `${provider === "anthropic" ? "Claude" : "OpenAI"} keys start with "${PREFIXES[provider]}"` },
+        { status: 400 }
+      );
+    }
+
+    const { enc, last4: last4Field } = fieldNames(provider);
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { [enc]: encryptSecret(apiKey), [last4Field]: last4(apiKey) },
+    });
+
+    return NextResponse.json({ ok: true, last4: last4(apiKey) });
+  } catch (e: any) {
+    if (e?.message === "UNAUTHENTICATED") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    console.error("[account/keys] save failed:", e?.message || e);
+    return NextResponse.json({ error: "Failed to save key" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const user = await requireUserOrThrow();
+    const body = await req.json().catch(() => ({}));
+    const provider = body?.provider as Provider;
+
+    if (provider !== "anthropic" && provider !== "openai") {
+      return NextResponse.json({ error: "Unknown provider" }, { status: 400 });
+    }
+
+    const { enc, last4: last4Field } = fieldNames(provider);
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { [enc]: null, [last4Field]: null },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    if (e?.message === "UNAUTHENTICATED") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "Failed to remove key" }, { status: 500 });
+  }
+}

--- a/app/api/forge/route.ts
+++ b/app/api/forge/route.ts
@@ -1,16 +1,18 @@
 // app/api/forge/route.ts
 // Turns a text prompt into a synthesis patch using a real LLM. Supports two
-// providers via server-side keys:
-//   - Claude  → ANTHROPIC_API_KEY  (official @anthropic-ai/sdk)
-//   - OpenAI  → OPENAI_API_KEY     (official openai sdk)
+// providers, each resolvable from either the signed-in user's own stored key
+// (Settings → AI Forge API keys) or a server-side fallback key:
+//   - Claude  → user key, else ANTHROPIC_API_KEY  (official @anthropic-ai/sdk)
+//   - OpenAI  → user key, else OPENAI_API_KEY      (official openai sdk)
 // The model reads the words in the prompt and emits patch JSON, so every
-// prompt produces a genuinely different sound. If no provider is configured
-// (or the call fails), we fall back to a prompt-keyword heuristic so the Forge
-// still varies its output.
+// prompt produces a genuinely different sound. If no key is available for the
+// chosen provider (or the call fails), we fall back to a prompt-keyword
+// heuristic so the Forge still varies its output.
 import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
 import OpenAI from "openai";
-import { requireUserOrThrow } from "@/lib/auth";
+import { requireUser, requireUserOrThrow } from "@/lib/auth";
+import { decryptSecret } from "@/lib/crypto";
 import {
   parsePatch,
   heuristicPatch,
@@ -22,12 +24,23 @@ const CLAUDE_MODEL = process.env.FORGE_CLAUDE_MODEL || "claude-opus-4-8";
 const OPENAI_MODEL = process.env.FORGE_OPENAI_MODEL || "gpt-4o";
 
 type Provider = "claude" | "openai";
+type KeySource = "user" | "server";
 
-function configuredProviders(): Provider[] {
-  const list: Provider[] = [];
-  if (process.env.ANTHROPIC_API_KEY) list.push("claude");
-  if (process.env.OPENAI_API_KEY) list.push("openai");
-  return list;
+/** Resolve which key (if any) is usable for a provider, and where it came from. */
+function resolveKey(
+  provider: Provider,
+  user: { anthropicKeyEnc?: string | null; openaiKeyEnc?: string | null } | null
+): { apiKey: string; source: KeySource } | null {
+  const encrypted = provider === "claude" ? user?.anthropicKeyEnc : user?.openaiKeyEnc;
+  if (encrypted) {
+    try {
+      return { apiKey: decryptSecret(encrypted), source: "user" };
+    } catch (e) {
+      console.error(`[forge] failed to decrypt stored ${provider} key:`, e);
+    }
+  }
+  const serverKey = provider === "claude" ? process.env.ANTHROPIC_API_KEY : process.env.OPENAI_API_KEY;
+  return serverKey ? { apiKey: serverKey, source: "server" } : null;
 }
 
 const SYSTEM_PROMPT = `You are a sound-design engine for a browser synthesizer. Given a short text
@@ -93,8 +106,8 @@ function extractJson(text: string): unknown {
   throw new Error("Unbalanced JSON in model output");
 }
 
-async function generateWithClaude(req: ForgeRequest): Promise<ForgePatch> {
-  const client = new Anthropic();
+async function generateWithClaude(req: ForgeRequest, apiKey: string): Promise<ForgePatch> {
+  const client = new Anthropic({ apiKey });
   const res = await client.messages.create({
     model: CLAUDE_MODEL,
     max_tokens: 1500,
@@ -109,8 +122,8 @@ async function generateWithClaude(req: ForgeRequest): Promise<ForgePatch> {
   return parsePatch(extractJson(text));
 }
 
-async function generateWithOpenAI(req: ForgeRequest): Promise<ForgePatch> {
-  const client = new OpenAI();
+async function generateWithOpenAI(req: ForgeRequest, apiKey: string): Promise<ForgePatch> {
+  const client = new OpenAI({ apiKey });
   const res = await client.chat.completions.create({
     model: OPENAI_MODEL,
     response_format: { type: "json_object" },
@@ -123,14 +136,25 @@ async function generateWithOpenAI(req: ForgeRequest): Promise<ForgePatch> {
   return parsePatch(extractJson(text));
 }
 
-/** GET → which providers the server can use, so the UI can offer them. */
+/** GET → which providers are usable right now (server key and/or the signed-in user's own key). */
 export async function GET() {
-  return NextResponse.json({ providers: configuredProviders() });
+  const user = await requireUser(); // non-throwing; null if not signed in
+  const claudeKey = resolveKey("claude", user);
+  const openaiKey = resolveKey("openai", user);
+
+  return NextResponse.json({
+    // Kept for backward compatibility with the current Forge UI.
+    providers: [claudeKey && "claude", openaiKey && "openai"].filter(Boolean),
+    detail: {
+      claude: { available: !!claudeKey, source: claudeKey?.source ?? null },
+      openai: { available: !!openaiKey, source: openaiKey?.source ?? null },
+    },
+  });
 }
 
 export async function POST(req: NextRequest) {
   try {
-    await requireUserOrThrow();
+    const user = await requireUserOrThrow();
     const body = await req.json();
 
     const forgeReq: ForgeRequest = {
@@ -146,7 +170,11 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Prompt is required" }, { status: 400 });
     }
 
-    const available = configuredProviders();
+    const resolved: Partial<Record<Provider, { apiKey: string; source: KeySource }>> = {
+      claude: resolveKey("claude", user) ?? undefined,
+      openai: resolveKey("openai", user) ?? undefined,
+    };
+    const available = (["claude", "openai"] as Provider[]).filter((p) => resolved[p]);
     const requested = body?.provider as Provider | "auto" | undefined;
 
     let provider: Provider | null = null;
@@ -157,15 +185,17 @@ export async function POST(req: NextRequest) {
     }
 
     if (provider) {
+      const key = resolved[provider]!;
       try {
         const patch =
           provider === "claude"
-            ? await generateWithClaude(forgeReq)
-            : await generateWithOpenAI(forgeReq);
+            ? await generateWithClaude(forgeReq, key.apiKey)
+            : await generateWithOpenAI(forgeReq, key.apiKey);
         return NextResponse.json({
           patch,
           provider,
           model: provider === "claude" ? CLAUDE_MODEL : OPENAI_MODEL,
+          keySource: key.source,
           source: "ai",
         });
       } catch (e: any) {
@@ -178,6 +208,7 @@ export async function POST(req: NextRequest) {
       patch: heuristicPatch(forgeReq),
       provider: null,
       model: null,
+      keySource: null,
       source: "fallback",
       reason: available.length === 0 ? "no-provider-configured" : "ai-error",
     });

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -114,6 +114,7 @@ export default function TopBar() {
                   </div>
                   <Link href="/" className="block px-3 py-2 rounded-md hover:bg-white/10 mt-1">Studio</Link>
                   <Link href="/ai" className="block px-3 py-2 rounded-md hover:bg-white/10">AI Forge</Link>
+                  <Link href="/account" className="block px-3 py-2 rounded-md hover:bg-white/10">Settings</Link>
                   <button onClick={logout} className="w-full text-left px-3 py-2 rounded-md hover:bg-white/10 text-rose-300">
                     Log out
                   </button>

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -1,0 +1,50 @@
+// lib/crypto.ts
+// AES-256-GCM helpers for encrypting user-supplied secrets (e.g. bring-your-own
+// AI provider API keys) before they touch the database. Never store these
+// values in plaintext — DB access or a backup leak would otherwise hand out
+// live API keys.
+import crypto from "node:crypto";
+
+const ALGO = "aes-256-gcm";
+const IV_LEN = 12; // GCM standard nonce size
+
+function getKey(): Buffer {
+  const raw = process.env.SECRETS_ENCRYPTION_KEY;
+  if (!raw) {
+    throw new Error(
+      "SECRETS_ENCRYPTION_KEY is not set. Generate one with `openssl rand -base64 32` and add it to your environment."
+    );
+  }
+  // Accept base64 (preferred) or hex, either way must decode to 32 bytes.
+  const buf = /^[A-Fa-f0-9]{64}$/.test(raw) ? Buffer.from(raw, "hex") : Buffer.from(raw, "base64");
+  if (buf.length !== 32) {
+    throw new Error("SECRETS_ENCRYPTION_KEY must decode to exactly 32 bytes (base64 or hex).");
+  }
+  return buf;
+}
+
+/** Encrypt a UTF-8 string. Returns `iv:authTag:ciphertext`, all base64. */
+export function encryptSecret(plaintext: string): string {
+  const key = getKey();
+  const iv = crypto.randomBytes(IV_LEN);
+  const cipher = crypto.createCipheriv(ALGO, key, iv);
+  const enc = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${iv.toString("base64")}:${tag.toString("base64")}:${enc.toString("base64")}`;
+}
+
+/** Decrypt a string produced by encryptSecret. Throws if tampered or wrong key. */
+export function decryptSecret(payload: string): string {
+  const key = getKey();
+  const [ivB64, tagB64, dataB64] = payload.split(":");
+  if (!ivB64 || !tagB64 || !dataB64) throw new Error("Malformed encrypted payload");
+  const decipher = crypto.createDecipheriv(ALGO, key, Buffer.from(ivB64, "base64"));
+  decipher.setAuthTag(Buffer.from(tagB64, "base64"));
+  const dec = Buffer.concat([decipher.update(Buffer.from(dataB64, "base64")), decipher.final()]);
+  return dec.toString("utf8");
+}
+
+/** Last 4 chars of a secret, for display (e.g. "sk-...WXYZ"). Never log the full value. */
+export function last4(secret: string): string {
+  return secret.slice(-4);
+}

--- a/prisma/migrations/20260701000000_add_user_api_keys/migration.sql
+++ b/prisma/migrations/20260701000000_add_user_api_keys/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "public"."User"
+  ADD COLUMN "anthropicKeyEnc" TEXT,
+  ADD COLUMN "anthropicKeyLast4" TEXT,
+  ADD COLUMN "openaiKeyEnc" TEXT,
+  ADD COLUMN "openaiKeyLast4" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,13 @@ model User {
   createdAt         DateTime            @default(now())
   updatedAt         DateTime            @updatedAt
   VerificationToken VerificationToken[]
+
+  // Bring-your-own AI provider keys for the AI Forge. Stored encrypted
+  // (see lib/crypto.ts) — only the last 4 chars are ever returned to the client.
+  anthropicKeyEnc   String?
+  anthropicKeyLast4 String?
+  openaiKeyEnc      String?
+  openaiKeyLast4    String?
 }
 
 model VerificationToken {


### PR DESCRIPTION
Lets each signed-in user store their own Claude/OpenAI key from a new Settings page instead of relying solely on the server's shared key, so the Forge can run against a user's own account and quota.

- Settings link added to the top-right avatar menu -> new /account page with a Profile section and an "AI Forge API keys" section (add/remove a key per provider, masked last-4 display only).
- lib/crypto.ts: AES-256-GCM encrypt/decrypt for secrets at rest, keyed by a new SECRETS_ENCRYPTION_KEY env var. Full key values are never returned to the client after saving.
- prisma: User gets anthropicKeyEnc/anthropicKeyLast4 and openaiKeyEnc/openaiKeyLast4 columns. Migration SQL is hand-written (the dev DB wasn't reachable from this session) - run via `npx prisma migrate deploy` once you have connectivity.
- app/api/account/keys: GET (masked status) / POST (validate + encrypt + save) / DELETE per provider.
- app/api/forge: resolves a key per request in priority order - the signed-in user's own stored key, then the server's ANTHROPIC_API_KEY/ OPENAI_API_KEY, then the on-device heuristic fallback. Response now reports keySource ("user" | "server" | null) so the UI can show which key served a given generation.

Requires SECRETS_ENCRYPTION_KEY to be set (e.g. `openssl rand -base64 32`) before users can save keys.